### PR TITLE
fix(TypeormUtils): change types of provider tokens

### DIFF
--- a/lib/common/typeorm.utils.ts
+++ b/lib/common/typeorm.utils.ts
@@ -40,36 +40,36 @@ export function getCustomRepositoryToken(repository: Function) {
  * This function returns a Connection injection token for the given Connection, ConnectionOptions or connection name.
  * @param {Connection | ConnectionOptions | string} [connection='default'] This optional parameter is either
  * a Connection, or a ConnectionOptions or a string.
- * @returns {string | Function} The Connection injection token.
+ * @returns {string | Type<Connection>} The Connection injection token.
  */
 export function getConnectionToken(
   connection: Connection | ConnectionOptions | string = 'default',
-): string | Function | Type<Connection> {
+): string | Type<Connection> {
   return 'default' === connection
     ? Connection
     : 'string' === typeof connection
-      ? `${connection}Connection`
-      : 'default' === connection.name || !connection.name
-        ? Connection
-        : `${connection.name}Connection`;
+    ? `${connection}Connection`
+    : 'default' === connection.name || !connection.name
+    ? Connection
+    : `${connection.name}Connection`;
 }
 
 /**
  * This function returns an EntityManager injection token for the given Connection, ConnectionOptions or connection name.
  * @param {Connection | ConnectionOptions | string} [connection='default'] This optional parameter is either
  * a Connection, or a ConnectionOptions or a string.
- * @returns {string | Function} The EntityManager injection token.
+ * @returns {string | Type<EntityManager>} The EntityManager injection token.
  */
 export function getEntityManagerToken(
   connection: Connection | ConnectionOptions | string = 'default',
-): string | Function {
+): string | Type<EntityManager> {
   return 'default' === connection
     ? EntityManager
     : 'string' === typeof connection
-      ? `${connection}EntityManager`
-      : 'default' === connection.name || !connection.name
-        ? EntityManager
-        : `${connection.name}EntityManager`;
+    ? `${connection}EntityManager`
+    : 'default' === connection.name || !connection.name
+    ? EntityManager
+    : `${connection.name}EntityManager`;
 }
 
 export function handleRetry(


### PR DESCRIPTION
Since nest v6, providers are typed. They only allow for 'string | symbol | Type<any>'
and not for Function.

closes nestjs/nest#1747

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) -> No tests in typeorm?!
- [x] Docs have been added / updated (for bug fixes / features) -> Not necessary.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
Issue Number: nestjs/nest#1747

## What is the new behavior?
`getConnectionToken` and `getEntityManagerToken` now return `Type<...>` instead of `Function`. I think this is preferable than allowing `Function` in the `Provider` interface.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```